### PR TITLE
Updated CI workflow with Go setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,4 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - run: make test


### PR DESCRIPTION
The Continuous Integration (CI) workflow has been updated to include the setup of Go. This is done using the 'actions/setup-go' action, which is configured to use the version specified in the 'go.mod' file. The addition of this step ensures that tests are run in an environment with the correct version of Go installed.
