### PR TITLE
Updated Ginkgo tool usage and removed unnecessary dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/unmango/devctl
 
 go 1.24.0
 
+tool github.com/onsi/ginkgo/v2/ginkgo
+
 require (
 	github.com/charmbracelet/log v0.4.0
 	github.com/onsi/ginkgo/v2 v2.23.0


### PR DESCRIPTION
The Makefile has been updated to use the 'go tool ginkgo' command instead of a local binary. This change simplifies the build process by removing the need to install Ginkgo locally. The dependency on the local Ginkgo binary has also been removed from several targets in the Makefile.

In addition, a new line was added to go.mod file to specify that Ginkgo is used as a tool. This makes it clear that Ginkgo is not a direct dependency of our application code, but rather a tool used during development and testing.
