### PR TITLE
Short: Corrected grammar in scaffold generation command description

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,7 +10,7 @@ type InitOptions struct{}
 func NewInit() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init [scaffold]",
-		Short: "Generates files the specified scaffold",
+		Short: "Generates files for the specified scaffold",
 	}
 
 	cmd.AddCommand(


### PR DESCRIPTION
In the 'init' command, fixed a minor grammatical error in the short description. It now accurately reflects that it generates files for the specified scaffold, improving clarity for users.
