### PR TITLE
Updated CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+          cache-dependency-path: go.sum
 
       - run: make test


### PR DESCRIPTION
Added caching for Go dependencies in the continuous integration workflow to improve build times. The cache is based on the go.sum file, which lists all project dependencies.
